### PR TITLE
Update build.hxml

### DIFF
--- a/source/build.hxml
+++ b/source/build.hxml
@@ -4,4 +4,5 @@
 -lib jQueryExtern
 -js ../bin/js/haxestudio.js
 -main Main
+-D source-map-content
 -debug


### PR DESCRIPTION
Embedding source maps could make development/debugging a lil bit easier. (You can view Haxe source code by clicking at console traces).
