### PR TITLE
Fix problem that write bracket causes crash.

### DIFF
--- a/plugin/plugin.misterpah.CodemirrorEditor/bin/CodemirrorEditor.js
+++ b/plugin/plugin.misterpah.CodemirrorEditor/bin/CodemirrorEditor.js
@@ -334,7 +334,7 @@
 		var trigger_anywordHint_only_when_see_this = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\t";
 
 		//console.log(trigger_anywordHint_only_when_see_this.search(char));
-		if (prefix.anywordHint_opened === false && trigger_anywordHint_only_when_see_this.search(char) > -1)
+		if (prefix.anywordHint_opened === false && trigger_anywordHint_only_when_see_this.indexOf(char) > -1)
 			{
 			prefix.cursor_position = pos_minus1;
 			prefix.anywordHint_opened = true;


### PR DESCRIPTION
Sorry for sudden pull-request.
When write a regular expression escape sequences like brackets in editor causes crash in Linux.
Cause of this problem is using "search" method.
I fix to use "indexOf" method.

It problem write in #54 .
